### PR TITLE
Correct bandwidth formula and use busbw for unify comparation

### DIFF
--- a/tune/bandwidth.py
+++ b/tune/bandwidth.py
@@ -82,28 +82,28 @@ def main():
         # 创建输入张量（torch.float16）
         input_data = torch.randn(size, dtype=torch.float16, device='cuda')
 
-        avg_time = perf_comm(1024, size // 1024, args.comm_op)
+        avg_time_ms = perf_comm(1024, size // 1024, args.comm_op)
+        avg_time_s = avg_time_ms / 1000.0  # elapsed_time() returns ms, convert to s
         
-        # 计算带宽（单位：GB/s）
+        # 计算 busbw（单位：GB/s）
         data_size_bytes = input_data.numel() * input_data.element_size()
         if args.comm_op == "all_reduce":
-            total_data_transferred = data_size_bytes * 2 * (world_size - 1) # AllReduce 的数据传输量
+            busbw = data_size_bytes * 2 * (world_size - 1) / world_size / avg_time_s / (1024 ** 3)
         elif args.comm_op == "reduce_scatter":
-            total_data_transferred = data_size_bytes * (world_size - 1) 
+            busbw = data_size_bytes * (world_size - 1) / world_size / avg_time_s / (1024 ** 3)
         else:
             raise ValueError("Unsupported communication operation")
 
-        bandwidth = (total_data_transferred / avg_time) / (1024 ** 3)  # 转换为 GB/s
-        bandwidths.append(bandwidth)
+        bandwidths.append(busbw)
 
         comm_array[i, 0] = size
-        comm_array[i, 1] = bandwidth
+        comm_array[i, 1] = busbw
         
     plt.plot(data_sizes, bandwidths, marker='o')
     # plt.xscale('log', base=2)
     plt.xlabel('Data Size (elements)')
-    plt.ylabel('Bandwidth (GB/s)')
-    plt.title('Bandwidth vs Data Size')
+    plt.ylabel('BusBW (GB/s)')
+    plt.title('Bus Bandwidth vs Data Size')
     plt.grid(True)
     plt.savefig('bandwidth.png', dpi=300, bbox_inches='tight')
     plt.show()

--- a/tune/bandwidth_multinode.py
+++ b/tune/bandwidth_multinode.py
@@ -122,20 +122,20 @@ def main():
             if rank == 0:
                 print(f"Testing size: {size/2**20:.1f}MB")
 
-            avg_time = perf_comm_test(1024, size // 1024, args.comm_op)
+            avg_time_ms = perf_comm_test(1024, size // 1024, args.comm_op)
+            avg_time_s = avg_time_ms / 1000.0  # elapsed_time() returns ms, convert to s
 
             if rank == 0:
-                # Calculate bandwidth (GB/s)
+                # Calculate busbw (GB/s)
                 data_size_bytes = size * 2  # float16 = 2 bytes
                 if args.comm_op == "all_reduce":
-                    total_data = data_size_bytes * 2 * (world_size - 1)
+                    busbw = data_size_bytes * 2 * (world_size - 1) / world_size / avg_time_s / (1024**3)
                 else:  # reduce_scatter
-                    total_data = data_size_bytes * (world_size - 1)
+                    busbw = data_size_bytes * (world_size - 1) / world_size / avg_time_s / (1024**3)
 
-                bandwidth = (total_data / (avg_time)) / (1024**3)  # GB/s
-                bandwidths.append(bandwidth)
+                bandwidths.append(busbw)
                 comm_array[i, 0] = size
-                comm_array[i, 1] = bandwidth
+                comm_array[i, 1] = busbw
 
             dist.barrier()  # Sync before next size
 
@@ -146,8 +146,8 @@ def main():
             plt.xscale('log', base=2)
             plt.yscale('log')
             plt.xlabel('Data Size (elements)')
-            plt.ylabel('Bandwidth (GB/s)')
-            plt.title(f'{args.comm_op} Bandwidth (World Size: {world_size})')
+            plt.ylabel('BusBW (GB/s)')
+            plt.title(f'{args.comm_op} Bus Bandwidth (World Size: {world_size})')
             plt.grid(True, which="both", ls="-")
             plt.savefig(f'bandwidth_{args.comm_op}_ws{world_size}.png', dpi=300, bbox_inches='tight')
 

--- a/tune/search.py
+++ b/tune/search.py
@@ -198,9 +198,10 @@ def interpolate_latency(samples, x, comm_op):
 
     # 使用 torch.interp 进行线性插值
     if comm_op == "all_reduce":
-        latency = x * 2 * 2 * (world_size - 1) / y / (1024 ** 3)
+        # busbw stored in GB/s; latency_ms = msgsize * 2*(n-1)/n / (busbw * GiB) * 1000
+        latency = x * 2 * 2 * (world_size - 1) / world_size / y / (1024 ** 3) * 1000
     elif comm_op == "reduce_scatter":
-        latency = x * 2 * (world_size - 1) / y / (1024 ** 3)
+        latency = x * 2 * (world_size - 1) / world_size / y / (1024 ** 3) * 1000
 
     return latency.item()
 

--- a/tune/search_multinode.py
+++ b/tune/search_multinode.py
@@ -302,9 +302,10 @@ def interpolate_latency(samples, x, comm_op):
     y = torch.tensor(y_np, dtype=torch.float32).item()
 
     if comm_op == "all_reduce":
-        latency = x * 2 * 2 * (world_size - 1) / y / (1024 ** 3)
+        # busbw stored in GB/s; latency_ms = msgsize * 2*(n-1)/n / (busbw * GiB) * 1000
+        latency = x * 2 * 2 * (world_size - 1) / world_size / y / (1024 ** 3) * 1000
     elif comm_op == "reduce_scatter":
-        latency = x * 2 * (world_size - 1) / y / (1024 ** 3)
+        latency = x * 2 * (world_size - 1) / world_size / y / (1024 ** 3) * 1000
 
     return latency.item()
 


### PR DESCRIPTION
1. elapsed_time() returns ms but was used as seconds.
2. use bus bandwidth so that allreduce/reducescatter can be compared, also easier to know if meet hardware limit.
@hkeee21 